### PR TITLE
added clusterise, pep8 style checked

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,7 @@ and vowel clusters. Keyword arguments are identical as for ``tokenise``:
 >>> clusterise("kiaːltaːʃ")
 ['k', 'iaː', 'lt', 'aː', 'ʃ']
 
+``clusterize`` is an alias for ``clusterise``
 
 pitfalls
 ========

--- a/README.rst
+++ b/README.rst
@@ -68,9 +68,9 @@ are collapsed into a single Chao letter (e.g. ``55 → ˥``).
 unknown=False, merge=None)`` takes an IPA string and returns a list of consonant 
 and vowel clusters. Keyword arguments are identical as for ``tokenise``:
   
-  >>> from ipatok import clusterise
-  >>> clusterise("kiaːltaːʃ")
-  ['k', 'iaː', 'lt', 'aː', 'ʃ']
+>>> from ipatok import clusterise
+>>> clusterise("kiaːltaːʃ")
+['k', 'iaː', 'lt', 'aː', 'ʃ']
 
 
 pitfalls

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,6 @@ keyword arguments:
 
 ``tokenize`` is an alias for ``tokenise``.
 
-
 other functions
 ---------------
 
@@ -63,6 +62,15 @@ are collapsed into a single Chao letter (e.g. ``55 → ˥``).
 
 >>> tokenise(replace_numbers_with_chao('ɕia⁵¹ɕyɛ²¹⁴'), tones=True)
 ['ɕ', 'i', 'a', '˥˩', 'ɕ', 'y', 'ɛ', '˨˩˦']
+
+
+``clusterise(string, strict=False, replace=False, diphthongs=False, tones=False,
+unknown=False, merge=None)`` takes an IPA string and returns a list of consonant 
+and vowel clusters. Keyword arguments are identical as for ``tokenise``:
+  
+  >>> from ipatok import clusterise
+  >>> clusterise("kiaːltaːʃ")
+  ['k', 'iaː', 'lt', 'aː', 'ʃ']
 
 
 pitfalls

--- a/ipatok/__init__.py
+++ b/ipatok/__init__.py
@@ -1,2 +1,2 @@
-from .tokens import tokenise, tokenize, clusterise, clusterize,
-replace_digits_with_chao
+from .tokens import (tokenise, tokenize, clusterise, clusterize,
+replace_digits_with_chao)

--- a/ipatok/__init__.py
+++ b/ipatok/__init__.py
@@ -1,1 +1,2 @@
-from .tokens import tokenise, tokenize, clusterise, clusterize, replace_digits_with_chao
+from .tokens import tokenise, tokenize, clusterise, clusterize,
+replace_digits_with_chao

--- a/ipatok/__init__.py
+++ b/ipatok/__init__.py
@@ -1,1 +1,1 @@
-from .tokens import tokenise, tokenize, replace_digits_with_chao
+from .tokens import tokenise, tokenize, clusterise, clusterize, replace_digits_with_chao

--- a/ipatok/ipa.py
+++ b/ipatok/ipa.py
@@ -3,7 +3,6 @@ import os.path
 import unicodedata
 
 
-
 """
 Paths to the ipatok/data dir and the two files in there.
 """
@@ -13,202 +12,200 @@ IPA_CHART_PATH = os.path.join(DATA_DIR, 'ipa_2015.tsv')
 REPLACEMENTS_PATH = os.path.join(DATA_DIR, 'replacements.tsv')
 
 
-
 class Chart:
-	"""
-	Object that loads and stores the valid IPA symbols.
-	"""
+    """
+    Object that loads and stores the valid IPA symbols.
+    """
 
-	def __init__(self):
-		"""
-		Init the instance's properties. All of these but the last one are
-		character sets, as needed by the is_ functions that comprise the
-		module's api. The last one is a dict mapping common substitutes to
-		their respective IPA counterparts.
-		"""
-		self.consonants = set()
-		self.vowels = set()
-		self.tie_bars = set()
-		self.diacritics = set()
-		self.suprasegmentals = set()
-		self.lengths = set()
-		self.tones = set()
+    def __init__(self):
+        """
+        Init the instance's properties. All of these but the last one are
+        character sets, as needed by the is_ functions that comprise the
+        module's api. The last one is a dict mapping common substitutes to
+        their respective IPA counterparts.
+        """
+        self.consonants = set()
+        self.vowels = set()
+        self.tie_bars = set()
+        self.diacritics = set()
+        self.suprasegmentals = set()
+        self.lengths = set()
+        self.tones = set()
 
-		self.replacements = {}
+        self.replacements = {}
 
-	def load_ipa(self, file_path):
-		"""
-		Populate the instance's set properties using the specified file.
-		"""
-		sections = {
-			'# consonants (pulmonic)': self.consonants,
-			'# consonants (non-pulmonic)': self.consonants,
-			'# other symbols': self.consonants,
-			'# tie bars': self.tie_bars,
-			'# vowels': self.vowels,
-			'# diacritics': self.diacritics,
-			'# suprasegmentals': self.suprasegmentals,
-			'# lengths': self.lengths,
-			'# tones and word accents': self.tones }
+    def load_ipa(self, file_path):
+        """
+        Populate the instance's set properties using the specified file.
+        """
+        sections = {
+            '# consonants (pulmonic)': self.consonants,
+            '# consonants (non-pulmonic)': self.consonants,
+            '# other symbols': self.consonants,
+            '# tie bars': self.tie_bars,
+            '# vowels': self.vowels,
+            '# diacritics': self.diacritics,
+            '# suprasegmentals': self.suprasegmentals,
+            '# lengths': self.lengths,
+            '# tones and word accents': self.tones}
 
-		curr_section = None
+        curr_section = None
 
-		with open(file_path, encoding='utf-8') as f:
-			for line in map(lambda x: x.strip(), f):
-				if line.startswith('#'):
-					if line in sections:
-						curr_section = sections[line]
-					else:
-						curr_section = None
-				elif line:
-					if curr_section is not None:
-						curr_section.add(line.split('\t')[0])
+        with open(file_path, encoding='utf-8') as f:
+            for line in map(lambda x: x.strip(), f):
+                if line.startswith('#'):
+                    if line in sections:
+                        curr_section = sections[line]
+                    else:
+                        curr_section = None
+                elif line:
+                    if curr_section is not None:
+                        curr_section.add(line.split('\t')[0])
 
-	def load_replacements(self, file_path):
-		"""
-		Populate self.replacements using the specified file.
-		"""
-		with open(file_path, encoding='utf-8') as f:
-			for line in map(lambda x: x.strip(), f):
-				if line:
-					line = line.split('\t')
-					self.replacements[line[0]] = line[1]
-
+    def load_replacements(self, file_path):
+        """
+        Populate self.replacements using the specified file.
+        """
+        with open(file_path, encoding='utf-8') as f:
+            for line in map(lambda x: x.strip(), f):
+                if line:
+                    line = line.split('\t')
+                    self.replacements[line[0]] = line[1]
 
 
 def ensure_single_char(func):
-	"""
-	Decorator that ensures that the first argument of the decorated function is
-	a single character, i.e. a string of length one.
-	"""
-	@functools.wraps(func)
-	def wrapper(*args, **kwargs):
-		if not isinstance(args[0], str) or len(args[0]) != 1:
-			raise ValueError((
-				'This function should be invoked with a string of length one '
-				'as its first argument'))
-		return func(*args, **kwargs)
+    """
+    Decorator that ensures that the first argument of the decorated function is
+    a single character, i.e. a string of length one.
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if not isinstance(args[0], str) or len(args[0]) != 1:
+            raise ValueError((
+                'This function should be invoked with a string of length one '
+                'as its first argument'))
+        return func(*args, **kwargs)
 
-	return wrapper
+    return wrapper
 
 
 @ensure_single_char
 def is_letter(char, strict=True):
-	"""
-	Check whether the character is a letter (as opposed to a diacritic or
-	suprasegmental).
+    """
+    Check whether the character is a letter (as opposed to a diacritic or
+    suprasegmental).
 
-	In strict mode return True only if the letter is part of the IPA spec.
-	"""
-	if (char in chart.consonants) or (char in chart.vowels):
-		return True
+    In strict mode return True only if the letter is part of the IPA spec.
+    """
+    if (char in chart.consonants) or (char in chart.vowels):
+        return True
 
-	if not strict:
-		return unicodedata.category(char) in ['Ll', 'Lo', 'Lt', 'Lu']
+    if not strict:
+        return unicodedata.category(char) in ['Ll', 'Lo', 'Lt', 'Lu']
 
-	return False
+    return False
 
 
 @ensure_single_char
 def is_vowel(char):
-	"""
-	Check whether the character is a vowel letter.
-	"""
-	if is_letter(char, strict=True):
-		return char in chart.vowels
+    """
+    Check whether the character is a vowel letter.
+    """
+    if is_letter(char, strict=True):
+        return char in chart.vowels
 
-	return False
+    return False
 
 
 @ensure_single_char
 def is_tie_bar(char):
-	"""
-	Check whether the character is one of the two IPA tie bar symbols.
-	"""
-	return char in chart.tie_bars
+    """
+    Check whether the character is one of the two IPA tie bar symbols.
+    """
+    return char in chart.tie_bars
 
 
 @ensure_single_char
 def is_diacritic(char, strict=True):
-	"""
-	Check whether the character is a diacritic (as opposed to a letter or a
-	suprasegmental).
+    """
+    Check whether the character is a diacritic (as opposed to a letter or a
+    suprasegmental).
 
-	In strict mode return True only if the diacritic is part of the IPA spec.
-	"""
-	if char in chart.diacritics:
-		return True
+    In strict mode return True only if the diacritic is part of the IPA spec.
+    """
+    if char in chart.diacritics:
+        return True
 
-	if not strict:
-		return (unicodedata.category(char) in ['Lm', 'Mn', 'Sk']) \
-				and (not is_suprasegmental(char)) \
-				and (not is_tie_bar(char)) \
-				and (not 0xA700 <= ord(char) <= 0xA71F)
+    if not strict:
+        return (unicodedata.category(char) in ['Lm', 'Mn', 'Sk']) \
+                and (not is_suprasegmental(char)) \
+                and (not is_tie_bar(char)) \
+                and (not 0xA700 <= ord(char) <= 0xA71F)
 
-	return False
+    return False
 
 
 @ensure_single_char
 def is_suprasegmental(char, strict=True):
-	"""
-	Check whether the character is a suprasegmental according to the IPA spec.
-	This includes tones, word accents, and length markers.
+    """
+    Check whether the character is a suprasegmental according to the IPA spec.
+    This includes tones, word accents, and length markers.
 
-	In strict mode return True only if the diacritic is part of the IPA spec.
-	"""
-	if (char in chart.suprasegmentals) or (char in chart.lengths):
-		return True
+    In strict mode return True only if the diacritic is part of the IPA spec.
+    """
+    if (char in chart.suprasegmentals) or (char in chart.lengths):
+        return True
 
-	return is_tone(char, strict)
+    return is_tone(char, strict)
 
 
 @ensure_single_char
 def is_length(char):
-	"""
-	Check whether the character is a length marker. Unlike other
-	suprasegmentals, length markers are included in the tokenised output.
-	"""
-	return char in chart.lengths
+    """
+    Check whether the character is a length marker. Unlike other
+    suprasegmentals, length markers are included in the tokenised output.
+    """
+    return char in chart.lengths
 
 
 @ensure_single_char
 def is_tone(char, strict=True):
-	"""
-	Check whether the character is a tone or word accent symbol. In strict mode
-	return True only for the symbols listed in the last group of the chart. If
-	strict=False, also accept symbols that belong to the Modifier Tone Letters
-	Unicode block [1].
+    """
+    Check whether the character is a tone or word accent symbol. In strict mode
+    return True only for the symbols listed in the last group of the chart. If
+    strict=False, also accept symbols that belong to the Modifier Tone Letters
+    Unicode block [1].
 
-	[1]: http://www.unicode.org/charts/PDF/UA700.pdf
-	"""
-	if char in chart.tones:
-		return True
+    [1]: http://www.unicode.org/charts/PDF/UA700.pdf
+    """
+    if char in chart.tones:
+        return True
 
-	if not strict:
-		return 0xA700 <= ord(char) <= 0xA71F
+    if not strict:
+        return 0xA700 <= ord(char) <= 0xA71F
 
-	return False
+    return False
 
 
 def get_precomposed_chars():
-	"""
-	Return the set of IPA characters that are defined in normal form C in the
-	spec. As of 2015, this is only the voiceless palatal fricative, ç.
-	"""
-	return set([
-		letter for letter in chart.consonants
-		if unicodedata.normalize('NFD', letter) != letter ])
+    """
+    Return the set of IPA characters that are defined in normal form C in the
+    spec. As of 2015, this is only the voiceless palatal fricative, ç.
+    """
+    return set([
+        letter for letter in chart.consonants
+        if unicodedata.normalize('NFD', letter) != letter])
 
 
 def replace_substitutes(string):
-	"""
-	Return the given string with all known common substitutes replaced with
-	their IPA-compliant counterparts.
-	"""
-	for non_ipa, ipa in chart.replacements.items():
-		string = string.replace(non_ipa, ipa)
+    """
+    Return the given string with all known common substitutes replaced with
+    their IPA-compliant counterparts.
+    """
+    for non_ipa, ipa in chart.replacements.items():
+        string = string.replace(non_ipa, ipa)
 
-	return string
+    return string
 
 
 """

--- a/ipatok/tests/test_ipa.py
+++ b/ipatok/tests/test_ipa.py
@@ -2,209 +2,208 @@ from functools import partial
 from unittest import TestCase
 
 from ipatok.ipa import (
-		is_letter, is_vowel, is_tie_bar, is_diacritic,
-		is_suprasegmental, is_length, is_tone,
-		get_precomposed_chars, replace_substitutes, chart)
-
+        is_letter, is_vowel, is_tie_bar, is_diacritic,
+        is_suprasegmental, is_length, is_tone,
+        get_precomposed_chars, replace_substitutes, chart)
 
 
 class IpaTestCase(TestCase):
 
-	def test_is_letter(self):
-		"""
-		is_letter should always return True for IPA letters and False for other
-		IPA symbols.
-		"""
-		for strict in [True, False]:
-			func = partial(is_letter, strict=strict)
+    def test_is_letter(self):
+        """
+        is_letter should always return True for IPA letters and False for other
+        IPA symbols.
+        """
+        for strict in [True, False]:
+            func = partial(is_letter, strict=strict)
 
-			self.assertTrue(func('p'))
-			self.assertTrue(func('ç'))
-			self.assertTrue(func('ʘ'))
-			self.assertTrue(func('ɥ'))
-			self.assertTrue(func('ɒ'))
+            self.assertTrue(func('p'))
+            self.assertTrue(func('ç'))
+            self.assertTrue(func('ʘ'))
+            self.assertTrue(func('ɥ'))
+            self.assertTrue(func('ɒ'))
 
-			self.assertFalse(func('ʰ'))
-			self.assertFalse(func('ʷ'))
-			self.assertFalse(func('꜍'))
+            self.assertFalse(func('ʰ'))
+            self.assertFalse(func('ʷ'))
+            self.assertFalse(func('꜍'))
 
-			[self.assertTrue(func(x)) for x in chart.consonants]
-			[self.assertTrue(func(x)) for x in chart.vowels]
+            [self.assertTrue(func(x)) for x in chart.consonants]
+            [self.assertTrue(func(x)) for x in chart.vowels]
 
-			[self.assertFalse(func(x)) for x in chart.tie_bars]
-			[self.assertFalse(func(x)) for x in chart.diacritics]
-			[self.assertFalse(func(x)) for x in chart.suprasegmentals]
-			[self.assertFalse(func(x)) for x in chart.lengths]
-			[self.assertFalse(func(x)) for x in chart.tones]
+            [self.assertFalse(func(x)) for x in chart.tie_bars]
+            [self.assertFalse(func(x)) for x in chart.diacritics]
+            [self.assertFalse(func(x)) for x in chart.suprasegmentals]
+            [self.assertFalse(func(x)) for x in chart.lengths]
+            [self.assertFalse(func(x)) for x in chart.tones]
 
-	def test_is_letter_non_ipa(self):
-		"""
-		is_letter should return False for non-IPA letters in strict mode and
-		True in non-strict mode.
-		"""
-		for char in ['ʣ', 'ɫ', 'g', 'Γ', 'F', 'ǈ']:
-			self.assertFalse(is_letter(char, strict=True))
-			self.assertTrue(is_letter(char, strict=False))
+    def test_is_letter_non_ipa(self):
+        """
+        is_letter should return False for non-IPA letters in strict mode and
+        True in non-strict mode.
+        """
+        for char in ['ʣ', 'ɫ', 'g', 'Γ', 'F', 'ǈ']:
+            self.assertFalse(is_letter(char, strict=True))
+            self.assertTrue(is_letter(char, strict=False))
 
-	def test_is_vowel(self):
-		"""
-		is_vowel should return True for IPA vowels and False for other IPA
-		symbols.
-		"""
-		self.assertTrue(is_vowel('i'))
-		self.assertTrue(is_vowel('ɶ'))
-		self.assertTrue(is_vowel('ɤ'))
-		self.assertTrue(is_vowel('ɒ'))
+    def test_is_vowel(self):
+        """
+        is_vowel should return True for IPA vowels and False for other IPA
+        symbols.
+        """
+        self.assertTrue(is_vowel('i'))
+        self.assertTrue(is_vowel('ɶ'))
+        self.assertTrue(is_vowel('ɤ'))
+        self.assertTrue(is_vowel('ɒ'))
 
-		self.assertFalse(is_vowel('ʍ'))
-		self.assertFalse(is_vowel('ɧ'))
-		self.assertFalse(is_vowel('꜍'))
+        self.assertFalse(is_vowel('ʍ'))
+        self.assertFalse(is_vowel('ɧ'))
+        self.assertFalse(is_vowel('꜍'))
 
-		[self.assertTrue(is_vowel(x)) for x in chart.vowels]
+        [self.assertTrue(is_vowel(x)) for x in chart.vowels]
 
-		[self.assertFalse(is_vowel(x)) for x in chart.consonants]
-		[self.assertFalse(is_vowel(x)) for x in chart.tie_bars]
-		[self.assertFalse(is_vowel(x)) for x in chart.diacritics]
-		[self.assertFalse(is_vowel(x)) for x in chart.suprasegmentals]
-		[self.assertFalse(is_vowel(x)) for x in chart.lengths]
-		[self.assertFalse(is_vowel(x)) for x in chart.tones]
+        [self.assertFalse(is_vowel(x)) for x in chart.consonants]
+        [self.assertFalse(is_vowel(x)) for x in chart.tie_bars]
+        [self.assertFalse(is_vowel(x)) for x in chart.diacritics]
+        [self.assertFalse(is_vowel(x)) for x in chart.suprasegmentals]
+        [self.assertFalse(is_vowel(x)) for x in chart.lengths]
+        [self.assertFalse(is_vowel(x)) for x in chart.tones]
 
-	def test_is_tie_bar(self):
-		"""
-		is_tie_bar should return True for IPA tie bars and False for other IPA
-		symbols.
-		"""
-		self.assertTrue(is_tie_bar('◌͡'[1]))
-		self.assertTrue(is_tie_bar('◌͜'[1]))
+    def test_is_tie_bar(self):
+        """
+        is_tie_bar should return True for IPA tie bars and False for other IPA
+        symbols.
+        """
+        self.assertTrue(is_tie_bar('◌͡'[1]))
+        self.assertTrue(is_tie_bar('◌͜'[1]))
 
-		self.assertFalse(is_tie_bar('ʋ'))
-		self.assertFalse(is_tie_bar('‿'))
+        self.assertFalse(is_tie_bar('ʋ'))
+        self.assertFalse(is_tie_bar('‿'))
 
-		[self.assertTrue(is_tie_bar(x)) for x in chart.tie_bars]
+        [self.assertTrue(is_tie_bar(x)) for x in chart.tie_bars]
 
-		[self.assertFalse(is_tie_bar(x)) for x in chart.consonants]
-		[self.assertFalse(is_tie_bar(x)) for x in chart.vowels]
-		[self.assertFalse(is_tie_bar(x)) for x in chart.diacritics]
-		[self.assertFalse(is_tie_bar(x)) for x in chart.suprasegmentals]
-		[self.assertFalse(is_tie_bar(x)) for x in chart.lengths]
-		[self.assertFalse(is_tie_bar(x)) for x in chart.tones]
+        [self.assertFalse(is_tie_bar(x)) for x in chart.consonants]
+        [self.assertFalse(is_tie_bar(x)) for x in chart.vowels]
+        [self.assertFalse(is_tie_bar(x)) for x in chart.diacritics]
+        [self.assertFalse(is_tie_bar(x)) for x in chart.suprasegmentals]
+        [self.assertFalse(is_tie_bar(x)) for x in chart.lengths]
+        [self.assertFalse(is_tie_bar(x)) for x in chart.tones]
 
-	def test_is_diacritic(self):
-		"""
-		is_diacritic should always return True for IPA diacritics and False for
-		other IPA symbols.
-		"""
-		for strict in [True, False]:
-			func = partial(is_diacritic, strict=strict)
+    def test_is_diacritic(self):
+        """
+        is_diacritic should always return True for IPA diacritics and False for
+        other IPA symbols.
+        """
+        for strict in [True, False]:
+            func = partial(is_diacritic, strict=strict)
 
-			self.assertTrue(func('◌̥'[1]))
-			self.assertTrue(func('◌ʰ'[1]))
-			self.assertTrue(func('◌̃'[1]))
-			self.assertTrue(func('◌̚'[1]))
+            self.assertTrue(func('◌̥'[1]))
+            self.assertTrue(func('◌ʰ'[1]))
+            self.assertTrue(func('◌̃'[1]))
+            self.assertTrue(func('◌̚'[1]))
 
-			self.assertFalse(func('ʌ'))
-			self.assertFalse(func('ˌ'))
-			self.assertFalse(func('ː'))
-			self.assertFalse(func('꜍'))
+            self.assertFalse(func('ʌ'))
+            self.assertFalse(func('ˌ'))
+            self.assertFalse(func('ː'))
+            self.assertFalse(func('꜍'))
 
-			[self.assertTrue(func(x)) for x in chart.diacritics]
+            [self.assertTrue(func(x)) for x in chart.diacritics]
 
-			[self.assertFalse(func(x)) for x in chart.consonants]
-			[self.assertFalse(func(x)) for x in chart.vowels]
-			[self.assertFalse(func(x)) for x in chart.tie_bars]
-			[self.assertFalse(func(x)) for x in chart.suprasegmentals]
-			[self.assertFalse(func(x)) for x in chart.lengths]
-			[self.assertFalse(func(x)) for x in chart.tones]
+            [self.assertFalse(func(x)) for x in chart.consonants]
+            [self.assertFalse(func(x)) for x in chart.vowels]
+            [self.assertFalse(func(x)) for x in chart.tie_bars]
+            [self.assertFalse(func(x)) for x in chart.suprasegmentals]
+            [self.assertFalse(func(x)) for x in chart.lengths]
+            [self.assertFalse(func(x)) for x in chart.tones]
 
-	def test_is_diacritic_non_ipa(self):
-		"""
-		is_diacritic should return False for non-IPA diacritics in strict mode
-		and True in non-strict mode.
-		"""
-		for char in ['ˀ', '◌̇'[1], '◌̣'[1]]:
-			self.assertFalse(is_diacritic(char, strict=True))
-			self.assertTrue(is_diacritic(char, strict=False))
+    def test_is_diacritic_non_ipa(self):
+        """
+        is_diacritic should return False for non-IPA diacritics in strict mode
+        and True in non-strict mode.
+        """
+        for char in ['ˀ', '◌̇'[1], '◌̣'[1]]:
+            self.assertFalse(is_diacritic(char, strict=True))
+            self.assertTrue(is_diacritic(char, strict=False))
 
-	def test_is_suprasegmental(self):
-		"""
-		is_suprasegmental should return True for IPA suprasegmentals and False
-		for other IPA symbols.
-		"""
-		for strict in [True, False]:
-			func = partial(is_suprasegmental, strict=strict)
+    def test_is_suprasegmental(self):
+        """
+        is_suprasegmental should return True for IPA suprasegmentals and False
+        for other IPA symbols.
+        """
+        for strict in [True, False]:
+            func = partial(is_suprasegmental, strict=strict)
 
-			self.assertTrue(func('ˈ'))
-			self.assertTrue(func('◌̋'[1]))
-			self.assertTrue(func('↘'))
-			self.assertTrue(func('.'))
-			self.assertTrue(func('‿'))
+            self.assertTrue(func('ˈ'))
+            self.assertTrue(func('◌̋'[1]))
+            self.assertTrue(func('↘'))
+            self.assertTrue(func('.'))
+            self.assertTrue(func('‿'))
 
-			self.assertFalse(func('ɮ'))
-			self.assertFalse(func('◌͜'[1]))
-			self.assertFalse(func('◌̝'[1]))
+            self.assertFalse(func('ɮ'))
+            self.assertFalse(func('◌͜'[1]))
+            self.assertFalse(func('◌̝'[1]))
 
-			[self.assertTrue(func(x)) for x in chart.suprasegmentals]
-			[self.assertTrue(func(x)) for x in chart.lengths]
-			[self.assertTrue(func(x)) for x in chart.tones]
+            [self.assertTrue(func(x)) for x in chart.suprasegmentals]
+            [self.assertTrue(func(x)) for x in chart.lengths]
+            [self.assertTrue(func(x)) for x in chart.tones]
 
-			[self.assertFalse(func(x)) for x in chart.consonants]
-			[self.assertFalse(func(x)) for x in chart.vowels]
-			[self.assertFalse(func(x)) for x in chart.tie_bars]
-			[self.assertFalse(func(x)) for x in chart.diacritics]
+            [self.assertFalse(func(x)) for x in chart.consonants]
+            [self.assertFalse(func(x)) for x in chart.vowels]
+            [self.assertFalse(func(x)) for x in chart.tie_bars]
+            [self.assertFalse(func(x)) for x in chart.diacritics]
 
-	def test_is_length(self):
-		"""
-		is_length should return True for IPA length markers and False for other
-		IPA symbols.
-		"""
-		self.assertTrue(is_length('ː'))
-		self.assertTrue(is_length('ˑ'))
-		self.assertTrue(is_length('◌̆'[1]))
+    def test_is_length(self):
+        """
+        is_length should return True for IPA length markers and False for other
+        IPA symbols.
+        """
+        self.assertTrue(is_length('ː'))
+        self.assertTrue(is_length('ˑ'))
+        self.assertTrue(is_length('◌̆'[1]))
 
-		self.assertFalse(is_length('ʼ'))
-		self.assertFalse(is_length('◌̃'[1]))
-		self.assertFalse(is_length('꜍'))
+        self.assertFalse(is_length('ʼ'))
+        self.assertFalse(is_length('◌̃'[1]))
+        self.assertFalse(is_length('꜍'))
 
-		[self.assertTrue(is_length(x)) for x in chart.lengths]
+        [self.assertTrue(is_length(x)) for x in chart.lengths]
 
-		[self.assertFalse(is_length(x)) for x in chart.consonants]
-		[self.assertFalse(is_length(x)) for x in chart.vowels]
-		[self.assertFalse(is_length(x)) for x in chart.tie_bars]
-		[self.assertFalse(is_length(x)) for x in chart.diacritics]
-		[self.assertFalse(is_length(x)) for x in chart.suprasegmentals]
-		[self.assertFalse(is_length(x)) for x in chart.tones]
+        [self.assertFalse(is_length(x)) for x in chart.consonants]
+        [self.assertFalse(is_length(x)) for x in chart.vowels]
+        [self.assertFalse(is_length(x)) for x in chart.tie_bars]
+        [self.assertFalse(is_length(x)) for x in chart.diacritics]
+        [self.assertFalse(is_length(x)) for x in chart.suprasegmentals]
+        [self.assertFalse(is_length(x)) for x in chart.tones]
 
-	def test_is_tone(self):
-		"""
-		is_tone should always return True for IPA tone and word accent symbols
-		and False for other IPA symbols.
-		"""
-		for strict in [True, False]:
-			func = partial(is_tone, strict=strict)
+    def test_is_tone(self):
+        """
+        is_tone should always return True for IPA tone and word accent symbols
+        and False for other IPA symbols.
+        """
+        for strict in [True, False]:
+            func = partial(is_tone, strict=strict)
 
-			[self.assertTrue(func(x)) for x in chart.tones]
+            [self.assertTrue(func(x)) for x in chart.tones]
 
-			[self.assertFalse(func(x)) for x in chart.consonants]
-			[self.assertFalse(func(x)) for x in chart.vowels]
-			[self.assertFalse(func(x)) for x in chart.tie_bars]
-			[self.assertFalse(func(x)) for x in chart.diacritics]
-			[self.assertFalse(func(x)) for x in chart.suprasegmentals]
-			[self.assertFalse(func(x)) for x in chart.lengths]
+            [self.assertFalse(func(x)) for x in chart.consonants]
+            [self.assertFalse(func(x)) for x in chart.vowels]
+            [self.assertFalse(func(x)) for x in chart.tie_bars]
+            [self.assertFalse(func(x)) for x in chart.diacritics]
+            [self.assertFalse(func(x)) for x in chart.suprasegmentals]
+            [self.assertFalse(func(x)) for x in chart.lengths]
 
-	def test_is_tone_non_ipa(self):
-		"""
-		is_tone should return False for non-IPA tone symbols in strict mode and
-		True in non-strict mode.
-		"""
-		for char in ['꜀', '꜍', 'ꜟ']:
-			self.assertFalse(is_tone(char, strict=True))
-			self.assertTrue(is_tone(char, strict=False))
+    def test_is_tone_non_ipa(self):
+        """
+        is_tone should return False for non-IPA tone symbols in strict mode and
+        True in non-strict mode.
+        """
+        for char in ['꜀', '꜍', 'ꜟ']:
+            self.assertFalse(is_tone(char, strict=True))
+            self.assertTrue(is_tone(char, strict=False))
 
-	def test_get_precomposed_chars(self):
-		self.assertEqual(get_precomposed_chars(), set(['ç']))
+    def test_get_precomposed_chars(self):
+        self.assertEqual(get_precomposed_chars(), set(['ç']))
 
-	def test_replace_substitutes(self):
-		self.assertEqual(replace_substitutes('g'), 'ɡ')
-		self.assertEqual(replace_substitutes('ł'), 'l̴')
-		self.assertEqual(replace_substitutes('ɫ'), 'l̴')
-		self.assertEqual(replace_substitutes('·'), 'ˑ')
+    def test_replace_substitutes(self):
+        self.assertEqual(replace_substitutes('g'), 'ɡ')
+        self.assertEqual(replace_substitutes('ł'), 'l̴')
+        self.assertEqual(replace_substitutes('ɫ'), 'l̴')
+        self.assertEqual(replace_substitutes('·'), 'ˑ')

--- a/ipatok/tests/test_tokens.py
+++ b/ipatok/tests/test_tokens.py
@@ -1,207 +1,244 @@
 from functools import partial
 from itertools import product
 from unittest import TestCase
+from unittest.mock import patch
 
 from ipatok.tokens import (
-		normalise, group, are_diphthong, tokenise, replace_digits_with_chao)
-
+        normalise, group, are_diphthong, tokenise, replace_digits_with_chao,
+        clusterise)
 
 
 class TokensTestCase(TestCase):
-	"""
-	The IPA strings are sourced from NorthEuraLex (languages: ady, ava, bul,
-	ckt, cmn, deu, eng).
-	"""
+    """
+    The IPA strings are sourced from NorthEuraLex (languages: ady, ava, bul,
+    ckt, cmn, deu, eng, hun).
+    """
 
-	def test_normalise(self):
-		"""
-		The voiceless palatal fricative should be in normal form C in the
-		output, regardless of its input form.
-		"""
-		self.assertEqual(normalise('nɪçt'), 'nɪçt')  # ç in normal form C
-		self.assertEqual(normalise('nɪçt'), 'nɪçt')  # ç in normal form D
+    def test_normalise(self):
+        """
+        The voiceless palatal fricative should be in normal form C in the
+        output, regardless of its input form.
+        """
+        self.assertEqual(normalise('nɪçt'), 'nɪçt')  # ç in normal form C
+        self.assertEqual(normalise('nɪçt'), 'nɪçt')  # ç in normal form D
 
-	def test_group(self):
-		self.assertEqual(group(lambda: True, []), [])
+    def test_group(self):
+        self.assertEqual(group(lambda: True, []), [])
 
-		for i in range(4, 1):
-			self.assertEqual(group(lambda x, y: x == y, ['a'] * i), ['a' * i])
+        for i in range(4, 1):
+            self.assertEqual(group(lambda x, y: x == y, ['a'] * i), ['a' * i])
 
-	def test_are_diphthong(self):
-		self.assertTrue(are_diphthong('ə', 'ə̯'))
-		self.assertTrue(are_diphthong('ə̯', 'ə'))
-		self.assertTrue(are_diphthong('ə̯', 'ə̯'))
-		self.assertFalse(are_diphthong('ə', 'ə'))
+    def test_are_diphthong(self):
+        self.assertTrue(are_diphthong('ə', 'ə̯'))
+        self.assertTrue(are_diphthong('ə̯', 'ə'))
+        self.assertTrue(are_diphthong('ə̯', 'ə̯'))
+        self.assertFalse(are_diphthong('ə', 'ə'))
 
-		self.assertTrue(are_diphthong('əə̯', 'ə̯'))
-		self.assertTrue(are_diphthong('ə̯ə', 'ə̯'))
-		self.assertFalse(are_diphthong('əə̯', 'ə'))
-		self.assertFalse(are_diphthong('ə̯ə', 'ə'))
+        self.assertTrue(are_diphthong('əə̯', 'ə̯'))
+        self.assertTrue(are_diphthong('ə̯ə', 'ə̯'))
+        self.assertFalse(are_diphthong('əə̯', 'ə'))
+        self.assertFalse(are_diphthong('ə̯ə', 'ə'))
 
-	def test_tokenise(self):
-		"""
-		IPA-compliant strings should be correctly tokenised, regardless of the
-		flag values.
-		"""
-		for comb in product(*[[True, False]] * 5):
-			func = partial(tokenise, strict=comb[0], replace=comb[1],
-							diphthongs=comb[2], tones=comb[3], unknown=comb[4])
+    def test_tokenise(self):
+        """
+        IPA-compliant strings should be correctly tokenised, regardless of the
+        flag values.
+        """
+        for comb in product(*[[True, False]] * 5):
+            func = partial(tokenise, strict=comb[0], replace=comb[1],
+                           diphthongs=comb[2], tones=comb[3], unknown=comb[4])
 
-			self.assertEqual(func('miq͡χː'), ['m', 'i', 'q͡χː'])
-			self.assertEqual(func('ʃːjeq͡χːʼjer'), ['ʃː', 'j', 'e', 'q͡χːʼ', 'j', 'e', 'r'])
-			self.assertEqual(func('t͡ɬʼibil'), ['t͡ɬʼ', 'i', 'b', 'i', 'l'])
-			self.assertEqual(func('ɬalkʼ'), ['ɬ', 'a', 'l', 'kʼ'])
+            self.assertEqual(func('miq͡χː'), ['m', 'i', 'q͡χː'])
+            self.assertEqual(func('ʃːjeq͡χːʼjer'),
+                             ['ʃː', 'j', 'e', 'q͡χːʼ', 'j', 'e', 'r'])
+            self.assertEqual(func('t͡ɬʼibil'), ['t͡ɬʼ', 'i', 'b', 'i', 'l'])
+            self.assertEqual(func('ɬalkʼ'), ['ɬ', 'a', 'l', 'kʼ'])
 
-			self.assertEqual(func('lit͡sɛ'), ['l', 'i', 't͡s', 'ɛ'])
-			self.assertEqual(func('t͡ʃɛʎust'), ['t͡ʃ', 'ɛ', 'ʎ', 'u', 's', 't'])
-			self.assertEqual(func('dirʲa'), ['d', 'i', 'rʲ', 'a'])
-			self.assertEqual(func('ut͡ʃa sɛ'), ['u', 't͡ʃ', 'a', 's', 'ɛ'])
+            self.assertEqual(func('lit͡sɛ'), ['l', 'i', 't͡s', 'ɛ'])
+            self.assertEqual(func('t͡ʃɛʎust'),
+                             ['t͡ʃ', 'ɛ', 'ʎ', 'u', 's', 't'])
+            self.assertEqual(func('dirʲa'), ['d', 'i', 'rʲ', 'a'])
+            self.assertEqual(func('ut͡ʃa sɛ'), ['u', 't͡ʃ', 'a', 's', 'ɛ'])
 
-			self.assertEqual(func('nɪçt'), ['n', 'ɪ', 'ç', 't'])
+            self.assertEqual(func('nɪçt'), ['n', 'ɪ', 'ç', 't'])
 
-			self.assertEqual(func('ˈd͡ʒɔɪ'), ['d͡ʒ', 'ɔ', 'ɪ'])
-			self.assertEqual(func('ˈtiːt͡ʃə'), ['t', 'iː', 't͡ʃ', 'ə'])
-			self.assertEqual(func('t͡ʃuːz'), ['t͡ʃ', 'uː', 'z'])
+            self.assertEqual(func('ˈd͡ʒɔɪ'), ['d͡ʒ', 'ɔ', 'ɪ'])
+            self.assertEqual(func('ˈtiːt͡ʃə'), ['t', 'iː', 't͡ʃ', 'ə'])
+            self.assertEqual(func('t͡ʃuːz'), ['t͡ʃ', 'uː', 'z'])
 
-	def test_tokenise_non_ipa(self):
-		"""
-		Tokenising non-compliant strings should raise ValueError unless strict
-		is False, regardless of the other flags' values.
-		"""
-		for comb in product(*[[True, False]] * 4):
-			func = partial(tokenise, replace=comb[0],
-							diphthongs=comb[1], tones=comb[2], unknown=comb[3])
+    def test_tokenise_non_ipa(self):
+        """
+        Tokenising non-compliant strings should raise ValueError unless strict
+        is False, regardless of the other flags' values.
+        """
+        for comb in product(*[[True, False]] * 4):
+            func = partial(tokenise, replace=comb[0],
+                           diphthongs=comb[1], tones=comb[2], unknown=comb[3])
 
-			with self.assertRaises(ValueError):
-				func('ʷəˈʁʷa', strict=True)
-			self.assertEqual(func('ʷəˈʁʷa', strict=False), ['ʷ', 'ə', 'ʁʷ', 'a'])
+            with self.assertRaises(ValueError):
+                func('ʷəˈʁʷa', strict=True)
+            self.assertEqual(func('ʷəˈʁʷa', strict=False),
+                             ['ʷ', 'ə', 'ʁʷ', 'a'])
 
-			with self.assertRaises(ValueError):
-				func('t͡ɕˀet͡ɕeŋ', strict=True)
-			self.assertEqual(func('t͡ɕˀet͡ɕeŋ', strict=False), ['t͡ɕˀ', 'e', 't͡ɕ', 'e', 'ŋ'])
+            with self.assertRaises(ValueError):
+                func('t͡ɕˀet͡ɕeŋ', strict=True)
+            self.assertEqual(func('t͡ɕˀet͡ɕeŋ', strict=False),
+                             ['t͡ɕˀ', 'e', 't͡ɕ', 'e', 'ŋ'])
 
-			with self.assertRaises(ValueError):
-				func('kat͡ɕˀaɹ', strict=True)
-			self.assertEqual(func('kat͡ɕˀaɹ', strict=False), ['k', 'a', 't͡ɕˀ', 'a', 'ɹ'])
+            with self.assertRaises(ValueError):
+                func('kat͡ɕˀaɹ', strict=True)
+            self.assertEqual(func('kat͡ɕˀaɹ', strict=False),
+                             ['k', 'a', 't͡ɕˀ', 'a', 'ɹ'])
 
-	def test_tokenise_replace(self):
-		"""
-		Strings containing common substitutes but otherwise IPA-compliant
-		should pass the strictness check only if replace is True.
-		"""
-		for comb in product(*[[True, False]] * 3):
-			func = partial(tokenise, strict=True,
-							diphthongs=comb[0], tones=comb[1], unknown=comb[2])
+    def test_tokenise_replace(self):
+        """
+        Strings containing common substitutes but otherwise IPA-compliant
+        should pass the strictness check only if replace is True.
+        """
+        for comb in product(*[[True, False]] * 3):
+            func = partial(tokenise, strict=True,
+                           diphthongs=comb[0], tones=comb[1], unknown=comb[2])
 
-			with self.assertRaises(ValueError):
-				func('t͡ʃɛɫɔ', replace=False)
-			self.assertEqual(func('t͡ʃɛɫɔ', replace=True), ['t͡ʃ', 'ɛ', 'l̴', 'ɔ'])
+            with self.assertRaises(ValueError):
+                func('t͡ʃɛɫɔ', replace=False)
+            self.assertEqual(func('t͡ʃɛɫɔ', replace=True),
+                             ['t͡ʃ', 'ɛ', 'l̴', 'ɔ'])
 
-			with self.assertRaises(ValueError):
-				func('ɫuna', replace=False)
-			self.assertEqual(func('ɫuna', replace=True), ['l̴', 'u', 'n', 'a'])
+            with self.assertRaises(ValueError):
+                func('ɫuna', replace=False)
+            self.assertEqual(func('ɫuna', replace=True), ['l̴', 'u', 'n', 'a'])
 
-	def test_tokenise_diphthongs(self):
-		"""
-		Diphthongs in IPA-compliant strings should be merged depending on the
-		diphthongs flag, regardless of the other flags' values.
-		"""
-		for comb in product(*[[True, False]] * 4):
-			func = partial(tokenise, strict=comb[0],
-							replace=comb[1], tones=comb[2], unknown=comb[3])
+    def test_tokenise_diphthongs(self):
+        """
+        Diphthongs in IPA-compliant strings should be merged depending on the
+        diphthongs flag, regardless of the other flags' values.
+        """
+        for comb in product(*[[True, False]] * 4):
+            func = partial(tokenise, strict=comb[0],
+                           replace=comb[1], tones=comb[2], unknown=comb[3])
 
-			self.assertEqual(func('t͡saɪ̯çən', diphthongs=False), ['t͡s', 'a', 'ɪ̯', 'ç', 'ə', 'n'])
-			self.assertEqual(func('t͡saɪ̯çən', diphthongs=True), ['t͡s', 'aɪ̯', 'ç', 'ə', 'n'])
+            self.assertEqual(func('t͡saɪ̯çən', diphthongs=False),
+                             ['t͡s', 'a', 'ɪ̯', 'ç', 'ə', 'n'])
+            self.assertEqual(func('t͡saɪ̯çən', diphthongs=True),
+                             ['t͡s', 'aɪ̯', 'ç', 'ə', 'n'])
 
-			self.assertEqual(func('hɛɐ̯t͡s', diphthongs=False), ['h', 'ɛ', 'ɐ̯', 't͡s'])
-			self.assertEqual(func('hɛɐ̯t͡s', diphthongs=True), ['h', 'ɛɐ̯', 't͡s'])
+            self.assertEqual(func('hɛɐ̯t͡s', diphthongs=False),
+                             ['h', 'ɛ', 'ɐ̯', 't͡s'])
+            self.assertEqual(func('hɛɐ̯t͡s', diphthongs=True),
+                             ['h', 'ɛɐ̯', 't͡s'])
 
-			self.assertEqual(func('moːɐ̯', diphthongs=False), ['m', 'oː', 'ɐ̯'])
-			self.assertEqual(func('moːɐ̯', diphthongs=True), ['m', 'oːɐ̯'])
+            self.assertEqual(func('moːɐ̯', diphthongs=False),
+                             ['m', 'oː', 'ɐ̯'])
+            self.assertEqual(func('moːɐ̯', diphthongs=True), ['m', 'oːɐ̯'])
 
-			self.assertEqual(func('aɪ̯çhœɐ̯nçən', diphthongs=False), ['a', 'ɪ̯', 'ç', 'h', 'œ', 'ɐ̯', 'n', 'ç', 'ə', 'n'])
-			self.assertEqual(func('aɪ̯çhœɐ̯nçən', diphthongs=True), ['aɪ̯', 'ç', 'h', 'œɐ̯', 'n', 'ç', 'ə', 'n'])
+            outx = ['a', 'ɪ̯', 'ç', 'h', 'œ', 'ɐ̯', 'n', 'ç', 'ə', 'n']
+            outy = ['aɪ̯', 'ç', 'h', 'œɐ̯', 'n', 'ç', 'ə', 'n']
+            self.assertEqual(func('aɪ̯çhœɐ̯nçən', diphthongs=False), outx)
+            self.assertEqual(func('aɪ̯çhœɐ̯nçən', diphthongs=True), outy)
 
-			self.assertEqual(func('klaʊ̯ə', diphthongs=False), ['k', 'l', 'a', 'ʊ̯', 'ə'])
-			self.assertEqual(func('klaʊ̯ə', diphthongs=True), ['k', 'l', 'aʊ̯', 'ə'])
+            self.assertEqual(func('klaʊ̯ə', diphthongs=False),
+                             ['k', 'l', 'a', 'ʊ̯', 'ə'])
+            self.assertEqual(func('klaʊ̯ə', diphthongs=True),
+                             ['k', 'l', 'aʊ̯', 'ə'])
 
-	def test_tokenise_tones(self):
-		"""
-		Tones in IPA-compliant strings should be tokenised or ignored depending
-		on the tones flag, regardless of other flags' values.
-		"""
-		for comb in product(*[[True, False]] * 4):
-			func = partial(tokenise, strict=comb[0],
-							replace=comb[1], diphthongs=comb[2], unknown=comb[3])
+    def test_tokenise_tones(self):
+        """
+        Tones in IPA-compliant strings should be tokenised or ignored depending
+        on the tones flag, regardless of other flags' values.
+        """
+        for comb in product(*[[True, False]] * 4):
+            func = partial(tokenise, strict=comb[0],
+                           replace=comb[1], diphthongs=comb[2],
+                           unknown=comb[3])
 
-			self.assertEqual(func('t͡sɯ˦ɕy˦', tones=True), ['t͡s', 'ɯ', '˦', 'ɕ', 'y', '˦'])
-			self.assertEqual(func('t͡sɯ˦ɕy˦', tones=False), ['t͡s', 'ɯ', 'ɕ', 'y'])
+            self.assertEqual(func('t͡sɯ˦ɕy˦', tones=True),
+                             ['t͡s', 'ɯ', '˦', 'ɕ', 'y', '˦'])
+            self.assertEqual(func('t͡sɯ˦ɕy˦', tones=False),
+                             ['t͡s', 'ɯ', 'ɕ', 'y'])
 
-			self.assertEqual(func('˨˩˦', tones=True), ['˨˩˦'])
-			self.assertEqual(func('˨˩˦', tones=False), [])
+            self.assertEqual(func('˨˩˦', tones=True), ['˨˩˦'])
+            self.assertEqual(func('˨˩˦', tones=False), [])
 
-			self.assertEqual(func('ə̋ə̏', tones=True), ['ə̋', 'ə̏'])
-			self.assertEqual(func('ə̋ə̏', tones=False), ['ə', 'ə'])
+            self.assertEqual(func('ə̋ə̏', tones=True), ['ə̋', 'ə̏'])
+            self.assertEqual(func('ə̋ə̏', tones=False), ['ə', 'ə'])
 
-	def test_tokenise_tones_non_ipa(self):
-		"""
-		Modifier tone letters should raise ValueError unless strict is False,
-		and should be otherwise tokenised only if tones is True.
-		"""
-		for comb in product(*[[True, False]] * 3):
-			func = partial(tokenise,
-							replace=comb[0], diphthongs=comb[1], unknown=comb[2])
+    def test_tokenise_tones_non_ipa(self):
+        """
+        Modifier tone letters should raise ValueError unless strict is False,
+        and should be otherwise tokenised only if tones is True.
+        """
+        for comb in product(*[[True, False]] * 3):
+            func = partial(tokenise,
+                           replace=comb[0], diphthongs=comb[1],
+                           unknown=comb[2])
 
-			for tones in [True, False]:
-				with self.assertRaises(ValueError):
-					func('꜍꜈', strict=True, tones=tones)
+            for tones in [True, False]:
+                with self.assertRaises(ValueError):
+                    func('꜍꜈', strict=True, tones=tones)
 
-			self.assertEqual(func('꜍꜈', strict=False, tones=False), [])
-			self.assertEqual(func('꜍꜈', strict=False, tones=True), ['꜍꜈'])
+            self.assertEqual(func('꜍꜈', strict=False, tones=False), [])
+            self.assertEqual(func('꜍꜈', strict=False, tones=True), ['꜍꜈'])
 
-	def test_tokenise_unknown(self):
-		"""
-		Unknown symbols should raise ValueError unless strict is False, in
-		which case they should be ignored depending on the unknown flag.
-		"""
-		for comb in product(*[[True, False]] * 3):
-			func = partial(tokenise, replace=comb[0], diphthongs=comb[1], tones=comb[2])
+    def test_tokenise_unknown(self):
+        """
+        Unknown symbols should raise ValueError unless strict is False, in
+        which case they should be ignored depending on the unknown flag.
+        """
+        for comb in product(*[[True, False]] * 3):
+            func = partial(tokenise, replace=comb[0], diphthongs=comb[1],
+                           tones=comb[2])
 
-			for unknown in [True, False]:
-				with self.assertRaises(ValueError):
-					func('-/$', strict=True, unknown=unknown)
+            for unknown in [True, False]:
+                with self.assertRaises(ValueError):
+                    func('-/$', strict=True, unknown=unknown)
 
-			self.assertEqual(func('-/$', unknown=True), ['-', '/', '$'])
-			self.assertEqual(func('-/$', unknown=False), [])
+            self.assertEqual(func('-/$', unknown=True), ['-', '/', '$'])
+            self.assertEqual(func('-/$', unknown=False), [])
 
-	def test_tokenise_splits_words(self):
-		"""
-		Whitespace characters and underscores should serve as word boundaries,
-		regardless of the flag values.
-		"""
-		for comb in product(*[[True, False]] * 5):
-			func = partial(tokenise, strict=comb[0], replace=comb[1],
-							diphthongs=comb[2], tones=comb[3], unknown=comb[4])
+    def test_tokenise_splits_words(self):
+        """
+        Whitespace characters and underscores should serve as word boundaries,
+        regardless of the flag values.
+        """
+        for comb in product(*[[True, False]] * 5):
+            func = partial(tokenise, strict=comb[0], replace=comb[1],
+                           diphthongs=comb[2], tones=comb[3], unknown=comb[4])
 
-			self.assertEqual(func('prɤst na krak'), ['p', 'r', 'ɤ', 's', 't', 'n', 'a', 'k', 'r', 'a', 'k'])
-			self.assertEqual(func('prɤst_na_krak'), ['p', 'r', 'ɤ', 's', 't', 'n', 'a', 'k', 'r', 'a', 'k'])
+            out3 = ['p', 'r', 'ɤ', 's', 't', 'n', 'a', 'k', 'r', 'a', 'k']
+            self.assertEqual(func('prɤst na krak'), out3)
+            out4 = ['p', 'r', 'ɤ', 's', 't', 'n', 'a', 'k', 'r', 'a', 'k']
+            self.assertEqual(func('prɤst_na_krak'), out4)
 
-			self.assertEqual(func('etɬə tite'), ['e', 't', 'ɬ', 'ə', 't', 'i', 't', 'e'])
-			self.assertEqual(func('etɬə_tite'), ['e', 't', 'ɬ', 'ə', 't', 'i', 't', 'e'])
+            out5 = ['e', 't', 'ɬ', 'ə', 't', 'i', 't', 'e']
+            self.assertEqual(func('etɬə tite'), out5)
+            out6 = ['e', 't', 'ɬ', 'ə', 't', 'i', 't', 'e']
+            self.assertEqual(func('etɬə_tite'), out6)
 
-	def test_replace_digits_with_chao(self):
-		"""
-		Digits should be correctly replaced with Chao tone letters, regardless
-		of the flag value and whether superscript or not.
-		"""
-		self.assertEqual(replace_digits_with_chao('ɕiŋ⁵⁵ɕiŋ²'), 'ɕiŋ˥ɕiŋ˨')
-		self.assertEqual(replace_digits_with_chao('ɕiŋ55ɕiŋ2'), 'ɕiŋ˥ɕiŋ˨')
+    def test_replace_digits_with_chao(self):
+        """
+        Digits should be correctly replaced with Chao tone letters, regardless
+        of the flag value and whether superscript or not.
+        """
+        self.assertEqual(replace_digits_with_chao('ɕiŋ⁵⁵ɕiŋ²'), 'ɕiŋ˥ɕiŋ˨')
+        self.assertEqual(replace_digits_with_chao('ɕiŋ55ɕiŋ2'), 'ɕiŋ˥ɕiŋ˨')
 
-		self.assertEqual(replace_digits_with_chao('ɕia⁵¹ɕyɛ²¹⁴'), 'ɕia˥˩ɕyɛ˨˩˦')
-		self.assertEqual(replace_digits_with_chao('ɕia51ɕyɛ214'), 'ɕia˥˩ɕyɛ˨˩˦')
+        self.assertEqual(replace_digits_with_chao('ɕia⁵¹ɕyɛ²¹⁴'),
+                         'ɕia˥˩ɕyɛ˨˩˦')
+        self.assertEqual(replace_digits_with_chao('ɕia51ɕyɛ214'),
+                         'ɕia˥˩ɕyɛ˨˩˦')
 
-		self.assertEqual(replace_digits_with_chao('ɕiŋ⁵⁵ɕiŋ²', inverse=True), 'ɕiŋ˩ɕiŋ˦')
-		self.assertEqual(replace_digits_with_chao('ɕiŋ55ɕiŋ2', inverse=True), 'ɕiŋ˩ɕiŋ˦')
+        self.assertEqual(replace_digits_with_chao('ɕiŋ⁵⁵ɕiŋ²', inverse=True),
+                         'ɕiŋ˩ɕiŋ˦')
+        self.assertEqual(replace_digits_with_chao('ɕiŋ55ɕiŋ2', inverse=True),
+                         'ɕiŋ˩ɕiŋ˦')
 
-		self.assertEqual(replace_digits_with_chao('ɕia⁵¹ɕyɛ²¹⁴', inverse=True), 'ɕia˩˥ɕyɛ˦˥˨')
-		self.assertEqual(replace_digits_with_chao('ɕia51ɕyɛ214', inverse=True), 'ɕia˩˥ɕyɛ˦˥˨')
+        self.assertEqual(replace_digits_with_chao('ɕia⁵¹ɕyɛ²¹⁴', inverse=True),
+                         'ɕia˩˥ɕyɛ˦˥˨')
+        self.assertEqual(replace_digits_with_chao('ɕia51ɕyɛ214', inverse=True),
+                         'ɕia˩˥ɕyɛ˦˥˨')
+
+    def test_clusterise(self):
+        with patch("ipatok.tokenise") as tokenise_mock:
+            tokenise_mock.return_value = ['k', 'i', 'aː', 'l', 't', 'aː', 'ʃ']
+            self.assertEqual(clusterise("kiaːltaːʃ"),
+                             ['k', 'iaː', 'lt', 'aː', 'ʃ'])

--- a/ipatok/tokens.py
+++ b/ipatok/tokens.py
@@ -3,180 +3,182 @@ import unicodedata
 from ipatok import ipa
 
 
-
 def normalise(string):
-	"""
-	Convert each character of the string to the normal form in which it was
-	defined in the IPA spec. This would be normal form D, except for the
-	voiceless palatar fricative (ç) which should be in normal form C.
+    """
+    Convert each character of the string to the normal form in which it was
+    defined in the IPA spec. This would be normal form D, except for the
+    voiceless palatar fricative (ç) which should be in normal form C.
 
-	Helper for tokenise_word(string, ..).
-	"""
-	string = unicodedata.normalize('NFD', string)
+    Helper for tokenise_word(string, ..).
+    """
+    string = unicodedata.normalize('NFD', string)
 
-	for char_c in ipa.get_precomposed_chars():
-		char_d = unicodedata.normalize('NFD', char_c)
-		if char_d in string:
-			string = string.replace(char_d, char_c)
+    for char_c in ipa.get_precomposed_chars():
+        char_d = unicodedata.normalize('NFD', char_c)
+        if char_d in string:
+            string = string.replace(char_d, char_c)
 
-	return string
+    return string
 
 
 def group(merge_func, tokens):
-	"""
-	Group together those of the tokens for which the merge function returns
-	true. The merge function should accept two arguments/tokens and should
-	return a boolean indicating whether the strings should be merged or not.
+    """
+    Group together those of the tokens for which the merge function returns
+    true. The merge function should accept two arguments/tokens and should
+    return a boolean indicating whether the strings should be merged or not.
 
-	Helper for tokenise(string, ..).
-	"""
-	output = []
+    Helper for tokenise(string, ..).
+    """
+    output = []
 
-	if tokens:
-		output.append(tokens[0])
+    if tokens:
+        output.append(tokens[0])
 
-		for token in tokens[1:]:
-			prev_token = output[-1]
+        for token in tokens[1:]:
+            prev_token = output[-1]
 
-			if merge_func(prev_token, token):
-				output[-1] += token
-			else:
-				output.append(token)
+            if merge_func(prev_token, token):
+                output[-1] += token
+            else:
+                output.append(token)
 
-	return output
+    return output
 
 
 def are_diphthong(tokenA, tokenB):
-	"""
-	Check (naively) whether the two tokens can form a diphthong. This would be
-	a sequence of vowels of which no more than one is syllabic. Vowel sequences
-	connected with a tie bar would already be handled in tokenise_word, so are
-	not checked for here.
+    """
+    Check (naively) whether the two tokens can form a diphthong. This would be
+    a sequence of vowels of which no more than one is syllabic. Vowel sequences
+    connected with a tie bar would already be handled in tokenise_word, so are
+    not checked for here.
 
-	Users who want more sophisticated diphthong detection should instead write
-	their own function and do something like::
+    Users who want more sophisticated diphthong detection should instead write
+    their own function and do something like::
 
-		tokenise(string, diphthong=False, merge=user_func)
+        tokenise(string, diphthong=False, merge=user_func)
 
-	Helper for tokenise(string, ..).
-	"""
-	is_short = lambda token: '◌̯'[1] in token
-	subtokens = []
+    Helper for tokenise(string, ..).
+    """
+    def is_short(token): return '◌̯'[1] in token
+    subtokens = []
 
-	for char in tokenA+tokenB:
-		if ipa.is_vowel(char):
-			subtokens.append(char)
-		elif ipa.is_diacritic(char) or ipa.is_length(char):
-			if subtokens:
-				subtokens[-1] += char
-			else:
-				break
-		else:
-			break
-	else:
-		if len([x for x in subtokens if not is_short(x)]) < 2:
-			return True
+    for char in tokenA+tokenB:
+        if ipa.is_vowel(char):
+            subtokens.append(char)
+        elif ipa.is_diacritic(char) or ipa.is_length(char):
+            if subtokens:
+                subtokens[-1] += char
+            else:
+                break
+        else:
+            break
+    else:
+        if len([x for x in subtokens if not is_short(x)]) < 2:
+            return True
 
-	return False
+    return False
 
 
 def tokenise_word(string,
-					strict=False, replace=False, tones=False, unknown=False):
-	"""
-	Tokenise the string into a list of tokens or raise ValueError if it cannot
-	be tokenised (relatively) unambiguously. The string should not include
-	whitespace, i.e. it is assumed to be a single word.
+                  strict=False, replace=False, tones=False, unknown=False):
+    """
+    Tokenise the string into a list of tokens or raise ValueError if it cannot
+    be tokenised (relatively) unambiguously. The string should not include
+    whitespace, i.e. it is assumed to be a single word.
 
-	If strict=False, allow non-standard letters and diacritics, as well as
-	initial diacritic-only tokens (e.g. pre-aspiration). If replace=True,
-	replace some common non-IPA symbols with their IPA counterparts. If
-	tones=False, ignore tone symbols. If unknown=False, ignore symbols that
-	cannot be classified into a relevant category.
+    If strict=False, allow non-standard letters and diacritics, as well as
+    initial diacritic-only tokens (e.g. pre-aspiration). If replace=True,
+    replace some common non-IPA symbols with their IPA counterparts. If
+    tones=False, ignore tone symbols. If unknown=False, ignore symbols that
+    cannot be classified into a relevant category.
 
-	Helper for tokenise(string, ..).
-	"""
-	string = normalise(string)
+    Helper for tokenise(string, ..).
+    """
+    string = normalise(string)
 
-	if replace:
-		string = ipa.replace_substitutes(string)
+    if replace:
+        string = ipa.replace_substitutes(string)
 
-	tokens = []
+    tokens = []
 
-	for index, char in enumerate(string):
-		if ipa.is_letter(char, strict):
-			if tokens and ipa.is_tie_bar(string[index-1]):
-				tokens[-1] += char
-			else:
-				tokens.append(char)
+    for index, char in enumerate(string):
+        if ipa.is_letter(char, strict):
+            if tokens and ipa.is_tie_bar(string[index-1]):
+                tokens[-1] += char
+            else:
+                tokens.append(char)
 
-		elif ipa.is_tie_bar(char):
-			if not tokens:
-				raise ValueError('The string starts with a tie bar: {}'.format(string))
-			tokens[-1] += char
+        elif ipa.is_tie_bar(char):
+            if not tokens:
+                raise ValueError(f'The string starts with a tie bar: {string}')
+            tokens[-1] += char
 
-		elif ipa.is_diacritic(char, strict) or ipa.is_length(char):
-			if tokens:
-				tokens[-1] += char
-			else:
-				if strict:
-					raise ValueError('The string starts with a diacritic: {}'.format(string))
-				else:
-					tokens.append(char)
+        elif ipa.is_diacritic(char, strict) or ipa.is_length(char):
+            if tokens:
+                tokens[-1] += char
+            else:
+                if strict:
+                    raise ValueError(f'string starts with diacritic: {string}')
+                else:
+                    tokens.append(char)
 
-		elif tones and ipa.is_tone(char, strict):
-			if unicodedata.combining(char):
-				if not tokens:
-					raise ValueError('The string starts with an accent mark: {}'.format(string))
-				tokens[-1] += char
-			elif tokens and ipa.is_tone(tokens[-1][-1], strict):
-				tokens[-1] += char
-			else:
-				tokens.append(char)
+        elif tones and ipa.is_tone(char, strict):
+            if unicodedata.combining(char):
+                if not tokens:
+                    msg = 'string starts with accent mark: {string}'
+                    raise ValueError(msg)
+                tokens[-1] += char
+            elif tokens and ipa.is_tone(tokens[-1][-1], strict):
+                tokens[-1] += char
+            else:
+                tokens.append(char)
 
-		elif ipa.is_suprasegmental(char, strict):
-			pass
+        elif ipa.is_suprasegmental(char, strict):
+            pass
 
-		else:
-			if strict:
-				raise ValueError('Unrecognised char: {} ({})'.format(char, unicodedata.name(char)))
-			elif unknown:
-				tokens.append(char)
-			else:
-				pass
+        else:
+            if strict:
+                msg = f'Unrecognised char: {char} ({ unicodedata.name(char)})'
+                raise ValueError(msg)
+            elif unknown:
+                tokens.append(char)
+            else:
+                pass
 
-	return tokens
+    return tokens
 
 
 def tokenise(string, strict=False, replace=False,
-					diphthongs=False, tones=False, unknown=False, merge=None):
-	"""
-	Tokenise an IPA string into a list of tokens. Raise ValueError if there is
-	a problem; if strict=True, this includes the string not being compliant to
-	the IPA spec.
+             diphthongs=False, tones=False, unknown=False, merge=None):
+    """
+    Tokenise an IPA string into a list of tokens. Raise ValueError if there is
+    a problem; if strict=True, this includes the string not being compliant to
+    the IPA spec.
 
-	If replace=True, replace some common non-IPA symbols with their IPA
-	counterparts. If diphthongs=True, try to group diphthongs into single
-	tokens. If tones=True, do not ignore tone symbols. If unknown=True, do not
-	ignore symbols that cannot be classified into a relevant category. If merge
-	is not None, use it for within-word token grouping.
+    If replace=True, replace some common non-IPA symbols with their IPA
+    counterparts. If diphthongs=True, try to group diphthongs into single
+    tokens. If tones=True, do not ignore tone symbols. If unknown=True, do not
+    ignore symbols that cannot be classified into a relevant category. If merge
+    is not None, use it for within-word token grouping.
 
-	Part of ipatok's public API.
-	"""
-	words = string.strip().replace('_', ' ').split()
-	output = []
+    Part of ipatok's public API.
+    """
+    words = string.strip().replace('_', ' ').split()
+    output = []
 
-	for word in words:
-		tokens = tokenise_word(word, strict, replace, tones, unknown)
+    for word in words:
+        tokens = tokenise_word(word, strict, replace, tones, unknown)
 
-		if diphthongs:
-			tokens = group(are_diphthong, tokens)
+        if diphthongs:
+            tokens = group(are_diphthong, tokens)
 
-		if merge is not None:
-			tokens = group(merge, tokens)
+        if merge is not None:
+            tokens = group(merge, tokens)
 
-		output.extend(tokens)
+        output.extend(tokens)
 
-	return output
+    return output
+
 
 def clusterise(ipastring):
     def merge(ipalist):
@@ -192,8 +194,7 @@ def clusterise(ipastring):
                 nextit = next(it)
             tmp.append(phon)
         yield ''.join(tmp)
-    return [i for i in merge(tokenise(ipastring)) if i]
-
+    return [i for i in merge(list(tokenise(ipastring))) if i]
 
 """
 Provide for the alternative spelling.
@@ -203,25 +204,25 @@ clusterize = clusterise
 
 
 def replace_digits_with_chao(string, inverse=False):
-	"""
-	Replace the digits 1-5 (also in superscript) with Chao tone letters. Equal
-	consecutive digits are collapsed into a single Chao letter.
+    """
+    Replace the digits 1-5 (also in superscript) with Chao tone letters. Equal
+    consecutive digits are collapsed into a single Chao letter.
 
-	If inverse=True, smaller digits are converted into higher tones; otherwise,
-	they are converted into lower tones (the default).
+    If inverse=True, smaller digits are converted into higher tones; otherwise,
+    they are converted into lower tones (the default).
 
-	Part of ipatok's public API.
-	"""
-	chao_letters = '˩˨˧˦˥'
+    Part of ipatok's public API.
+    """
+    chao_letters = '˩˨˧˦˥'
 
-	if inverse:
-		chao_letters = chao_letters[::-1]
+    if inverse:
+        chao_letters = chao_letters[::-1]
 
-	string = string.translate(str.maketrans('¹²³⁴⁵', '12345'))
-	string = string.translate(str.maketrans('12345', chao_letters))
+    string = string.translate(str.maketrans('¹²³⁴⁵', '12345'))
+    string = string.translate(str.maketrans('12345', chao_letters))
 
-	string = ''.join([
-		char for index, char in enumerate(string)
-		if not (index and char in chao_letters and string[index-1] == char)])
+    string = ''.join([
+        char for index, char in enumerate(string)
+        if not (index and char in chao_letters and string[index-1] == char)])
 
-	return string
+    return string

--- a/ipatok/tokens.py
+++ b/ipatok/tokens.py
@@ -180,21 +180,23 @@ def tokenise(string, strict=False, replace=False,
     return output
 
 
-def clusterise(ipastring):
+def clusterise(string, strict=False, replace=False,
+               diphthongs=False, tones=False, unknown=False, merge=None):
     def merge(ipalist):
         """merge subsequent consonants and vowels to clusters"""
         tmp = []
         it = iter(ipalist)
         nextit = next(it)
-        for phon in ipalist:
-            phoncv = any(ipa.is_vowel(i) for i in phon)
-            while any(ipa.is_vowel(i) for i in nextit) != phoncv:
+        for char in ipalist:
+            charcv = any(ipa.is_vowel(i) for i in char)
+            while any(ipa.is_vowel(i) for i in nextit) != charcv:
                 yield ''.join(tmp)
                 tmp = []
                 nextit = next(it)
-            tmp.append(phon)
+            tmp.append(char)
         yield ''.join(tmp)
-    return [i for i in merge(list(tokenise(ipastring))) if i]
+
+    return [i for i in merge(tokenise(string, list(locals().values()))) if i]
 
 """
 Provide for the alternative spelling.

--- a/ipatok/tokens.py
+++ b/ipatok/tokens.py
@@ -178,11 +178,28 @@ def tokenise(string, strict=False, replace=False,
 
 	return output
 
+def clusterise(ipastring):
+    def merge(ipalist):
+        """merge subsequent consonants and vowels to clusters"""
+        tmp = []
+        it = iter(ipalist)
+        nextit = next(it)
+        for phon in ipalist:
+            phoncv = any(ipa.is_vowel(i) for i in phon)
+            while any(ipa.is_vowel(i) for i in nextit) != phoncv:
+                yield ''.join(tmp)
+                tmp = []
+                nextit = next(it)
+            tmp.append(phon)
+        yield ''.join(tmp)
+    return [i for i in merge(tokenise(ipastring)) if i]
+
 
 """
 Provide for the alternative spelling.
 """
 tokenize = tokenise
+clusterize = clusterise
 
 
 def replace_digits_with_chao(string, inverse=False):

--- a/setup.py
+++ b/setup.py
@@ -7,44 +7,45 @@ BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 
 with open(os.path.join(BASE_DIR, 'README.rst')) as f:
-	README = f.read()
+    README = f.read()
 
 
 with open(os.path.join(BASE_DIR, 'ipatok/__version__.py')) as f:
-	exec(f.read())
+    exec(f.read())
 
 
 setup(
-	name = 'ipatok',
-	version = VERSION,
+    name='ipatok',
+    version=VERSION,
 
-	description = 'IPA tokeniser',
-	long_description = README,
-	long_description_content_type='text/x-rst',
+    description='IPA tokeniser',
+    long_description=README,
+    long_description_content_type='text/x-rst',
 
-	url = 'https://github.com/pavelsof/ipatok',
-	author = 'pavelsof',
-	author_email = 'mail@pavelsof.com',
+    url='https://github.com/pavelsof/ipatok',
+    author='pavelsof',
+    author_email='mail@pavelsof.com',
 
-	classifiers = [
-		'Development Status :: 4 - Beta',
-		'Intended Audience :: Science/Research',
-		'License :: OSI Approved :: MIT License',
-		'Programming Language :: Python :: 3',
-		'Topic :: Text Processing :: Linguistic',
-	],
-	keywords = 'IPA tokeniser tokenizer',
-	project_urls = {
-		'Changelog': 'https://github.com/pavelsof/ipatok/blob/master/CHANGELOG.rst',
-		'Source': 'https://github.com/pavelsof/ipatok',
-		'Tracker': 'https://github.com/pavelsof/ipatok/issues',
-	},
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3',
+        'Topic :: Text Processing :: Linguistic',
+    ],
+    keywords='IPA tokeniser tokenizer',
+    project_urls={
+        'Changelog':
+            'https://github.com/pavelsof/ipatok/blob/master/CHANGELOG.rst',
+        'Source': 'https://github.com/pavelsof/ipatok',
+        'Tracker': 'https://github.com/pavelsof/ipatok/issues',
+    },
 
-	packages = find_packages(),
-	package_data = {'ipatok': ['data/*']},
+    packages=find_packages(),
+    package_data={'ipatok': ['data/*']},
 
-	install_requires = [],
-	python_requires='>=3',
+    install_requires=[],
+    python_requires='>=3',
 
-	test_suite = 'ipatok.tests'
+    test_suite='ipatok.tests'
 )


### PR DESCRIPTION
I had been using this wrapper for more than a year now and thought it would be time to suggest including it in the source package. It takes the output of ``tokenise`` and clusters consonants and vowels together. This can't be achieved with the ``merge`` argument. I've added one unittest for this function, all tests are passing. Added a description to the readme. And added ``clusterise`` and ``clusterize`` to ``__init__.py``.
Apart from that I style checked all the .py files with pep8online.com so that they all fit the pep8 standards (spaces instead of tabs, max. line length of 79 chars etc), this doesn't affect functionality.