### PR TITLE
params weren't passed from clusterise to tokenise

### DIFF
--- a/ipatok/tests/test_tokens.py
+++ b/ipatok/tests/test_tokens.py
@@ -304,9 +304,15 @@ class TokensTestCase(TestCase):
         )
 
     def test_clusterise(self):
-        with patch("ipatok.tokenise") as tokenise_mock:
+        with patch("ipatok.tokens.tokenise") as tokenise_mock:
             tokenise_mock.return_value = ['k', 'i', 'aː', 'l', 't', 'aː', 'ʃ']
 
             self.assertEqual(
                 clusterise("kiaːltaːʃ"), ['k', 'iaː', 'lt', 'aː', 'ʃ']
             )
+            tokenise_mock.assert_called_with('kiaːltaːʃ', False, False, False, False, False, None)
+
+            self.assertEqual(
+                clusterise("kiaːltaːʃ", True, True, True, True, True, None), ['k', 'iaː', 'lt', 'aː', 'ʃ']
+            )
+            tokenise_mock.assert_called_with('kiaːltaːʃ', True, True, True, True, True, None)

--- a/ipatok/tokens.py
+++ b/ipatok/tokens.py
@@ -188,7 +188,7 @@ def tokenise(string, strict=False, replace=False,
 
 def clusterise(string, strict=False, replace=False,
                diphthongs=False, tones=False, unknown=False, merge=None):
-    def merge(ipalist):
+    def groupit(ipalist):
         """Merge subsequent consonants and vowels to clusters."""
         tmp = []
         it = iter(ipalist)
@@ -202,7 +202,8 @@ def clusterise(string, strict=False, replace=False,
             tmp.append(char)
         yield ''.join(tmp)
 
-    return [i for i in merge(tokenise(string, list(locals().values()))) if i]
+    args = list(locals().values())[:-1]  # last arg would be groupit()
+    return [i for i in groupit(tokenise(*args)) if i]
 
 
 def replace_digits_with_chao(string, inverse=False):


### PR DESCRIPTION
Line 205/206: instead of passing variadic arguments, they were converted to a list and assigned to the second argument ("strict"). Fixed that now. `[:-1]` is needed because locals() lists also the function groupit() in the end, which we don't want to pass on to tokenise. Renamed "merge()" to "groupit()", because "merge" is already the name of an argument. Didn't want to name it "group()" since it occurs elsewhere in the script already.